### PR TITLE
exclude `test` environment by default

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -28,7 +28,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->arrayNode('excluded_environments')
                     ->prototype('scalar')->end()
-                    ->defaultValue(['dev'])
+                    ->defaultValue(['dev', 'test'])
                 ->end()
                 ->arrayNode('excluded_exceptions')
                     ->prototype('scalar')->end()

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ By default (if the `excluded_exceptions` isn't specified), all exceptions are ha
 Here are some more things you can configure. Just add these items to your `config.yml`, under the `sym_exc_2_gtlb_isu_bndle`
 node.
 
-- `excluded_environments` - array, default `['dev']`:
+- `excluded_environments` - array, default `['dev', 'test']`:
 
     When encountering an exception in one of these environments, we won't report anything to your GitLab repository.
      


### PR DESCRIPTION
This leaves only the `prod` environment activated by default.
