### PR TITLE
fix ExceptionLoggingService::IssueTitleMaxLength

### DIFF
--- a/Service/ExceptionLoggingService.php
+++ b/Service/ExceptionLoggingService.php
@@ -14,7 +14,7 @@ class ExceptionLoggingService
     const CommentPattern = "Thrown {count} time{plural}, last one was {datetime}";
     const CommentRegex = "/^Thrown (\\d*) times?, last one was (.*)$/";
     const UnknownLoggedInUser = "None";
-    const IssueTitleMaxLength = 256;
+    const IssueTitleMaxLength = 255;
 
     /**
      * GitLab's API URL, defaults to hosted
@@ -160,7 +160,7 @@ class ExceptionLoggingService
     }
 
     /**
-     * GitLab issues titles are limited to 256 chars, let's truncate it if necessary
+     * GitLab issues titles are limited to 255 chars, let's truncate it if necessary
      * @param array $exceptionInfos
      * @return string
      */


### PR DESCRIPTION
The maximum length of an issue's title is 255 chars, not 256. This causes an exception in the underlying vender `m4tthumphrey/php-gitlab-api` which gets logged instead of the root exception.

![image](https://cloud.githubusercontent.com/assets/576772/19029583/c9942a1e-8947-11e6-8663-c9f34fb02fa1.png)
