### PR TITLE
fix username always being reported as `None`

### DIFF
--- a/Service/ExceptionLoggingService.php
+++ b/Service/ExceptionLoggingService.php
@@ -81,6 +81,7 @@ class ExceptionLoggingService
         $this->excludedEnvironments = $excludedEnvironments;
         $this->excludedExceptions = $excludedExceptions;
         $this->mentions = $mentions;
+        $this->tokenStorage = $tokenStorage;
 
         $this->twig = $twig;
         $this->env = $env;


### PR DESCRIPTION
The `TokenStorage` instance that was injected in the service constructor was never affected to `$this->tokenStorage` so the [username detection](https://github.com/MrMitch/SymfonyExceptions2GitLabIssuesBundle/blob/master/Service/ExceptionLoggingService.php#L221) always yielded `None`.