### PR TITLE
link to line where the exception was thrown

### DIFF
--- a/Resources/views/gitLabMessage.md.twig
+++ b/Resources/views/gitLabMessage.md.twig
@@ -8,7 +8,7 @@
 Logged-in user: {{ user }}
 {% endif %}
 
-Exception in *[{{ file ~ '#' ~ line }}]({{ file ~ '#' ~ line }})*.
+Exception in *[{{ file ~ '#' ~ line }}]({{ file ~ '#L' ~ line ~ '-' ~ line }})*.
 
 > {{ class }}
 > {{ message }}


### PR DESCRIPTION
Fix the link to the file that is shown in the issue description so that it scrolls to the right line (and highlights it).